### PR TITLE
Zookeeper service check fix.\n Command name is ZOOKEEPER_QUORUM_SERVI…

### DIFF
--- a/ambari_trigger_service_checks.py
+++ b/ambari_trigger_service_checks.py
@@ -356,6 +356,14 @@ class AmbariTriggerServiceChecks(CLI):
         for index in range(service_count):
             service = services[index]
             index += 1
+
+            commandData = ""
+            if service.upper() == "ZOOKEEPER" :
+              # this if block is needed because the ZOOKEEPRR service check command name is "ZOOKEEPER_QUORUM_SERVICE_CHECK" and not "ZOOKEEPER_SERVICE_CHECK"
+              commandData = "{service}_QUORUM_SERVICE_CHECK".format(service=service.upper())
+            else :
+              commandData = "{service}_SERVICE_CHECK".format(service=service.upper())
+
             payload[0]['RequestSchedule']['batch'][0]['requests'].append(
                 {
                     "order_id": index,
@@ -363,7 +371,7 @@ class AmbariTriggerServiceChecks(CLI):
                     "uri": "/api/v1/clusters/{0}/requests".format(self.cluster),
                     "RequestBodyInfo":{
                         "RequestInfo": {
-                            "command": "{service}_SERVICE_CHECK".format(service=service.upper()),
+                            "command": "{commandData}".format(commandData=commandData) ,
                             "context": "{service} Service Check (batch {index} of {total})".
                                        format(service=service, index=index, total=service_count)
                         },


### PR DESCRIPTION
The Zookeeper service name command name is actually "**ZOOKEEPER_QUORUM_SERVICE_CHECK**" and not "ZOOKEEPER_SERVICE_CHECK"
Hence the zookeeper service check will fail when we run:

`# python ambari_trigger_service_checks.py  -u admin -p admin -C plain_ambari --services=ZOOKEEPER --wait --timeout=500`

Reference Community Thread: https://community.hortonworks.com/questions/176909/ambari-trigger-service-checkspy-bug.html